### PR TITLE
Terrain Tessellation

### DIFF
--- a/Resources/Meshes/terrain.obj
+++ b/Resources/Meshes/terrain.obj
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bccb0040e2a80d2f20d2ce5bb086338e1a4a0f0d63c8e1248d150ae2fdd6545c
-size 573002
+oid sha256:426f3af532d490066e3c5c4c9c3baa1e093828e95ef864766a34655c46f50a78
+size 31509

--- a/Resources/Shaders/Includes/UniformBuffers.inc.shader
+++ b/Resources/Shaders/Includes/UniformBuffers.inc.shader
@@ -35,7 +35,6 @@ layout(std140) uniform per_draw_data
 //Terrain uniform buffer
 layout(std140) uniform terrain_data
 {
-    uniform ivec4 _TerrainTileCount;
     uniform vec4 _TerrainTextureOffsetScale; // XY is offset, ZW is scale
     uniform vec4 _TerrainSize; // XYZ, W is layercount(int)
     uniform vec4 _TextureScale; // XY

--- a/Resources/Shaders/Terrain.shader
+++ b/Resources/Shaders/Terrain.shader
@@ -20,13 +20,9 @@ out vec3 tangentToWorld[3];
 
 void main()
 {
-    ivec2 tileIndex = ivec2(gl_InstanceID % _TerrainTileCount.x, gl_InstanceID / _TerrainTileCount.x); //_TerrainTileCount
-
     // Compute normalized position of the terrain. This ranges from 0,1 in XYZ
     // Use the x and z and take the y from the heightmap
     vec3 normalizedPosition = _position.xyz;
-    normalizedPosition.xz += tileIndex;
-    normalizedPosition.xz /= _TerrainTileCount.xy;
     normalizedPosition.y = texture(_TerrainHeightmap, normalizedPosition.xz).g;
 
     worldPosition = vec4(normalizedPosition * _TerrainSize.xyz, 1.0);

--- a/Resources/Shaders/Terrain.shader
+++ b/Resources/Shaders/Terrain.shader
@@ -19,27 +19,24 @@ void main()
 
 layout(vertices = 3) out;
 
-float tessAtPoint(vec4 normalizedPosition)
-{
-    vec3 worldPosition = normalizedPosition.xyz * _TerrainSize.xyz;
-    vec3 toCamera = _CameraPosition.xyz - worldPosition;
-    return clamp(64.0 - length(toCamera) * 0.15, 4.0, 64.0);
-}
-
 void main()
 {
     if (gl_InvocationID == 0)
     {
-        // Base the outer tessellation on the midpoint of each edge
-        // This ensures that edges shared between triangles receive the same tessellation factor
-        // on both sides of the edge, preventing gaps.
-        gl_TessLevelOuter[0] = tessAtPoint((gl_in[1].gl_Position + gl_in[2].gl_Position) / 2.0);
-        gl_TessLevelOuter[1] = tessAtPoint((gl_in[2].gl_Position + gl_in[0].gl_Position) / 2.0);
-        gl_TessLevelOuter[2] = tessAtPoint((gl_in[0].gl_Position + gl_in[1].gl_Position) / 2.0);
+        // Use the same amount of tessellation across the entire terrain to prevent
+        // popping / waving artifacts
 
-        // Make the inner tessellation level the average of the outer ones.
-        gl_TessLevelInner[0] = (gl_TessLevelOuter[0] + gl_TessLevelOuter[1] + gl_TessLevelOuter[2]) / 3.0;
-        gl_TessLevelInner[1] = gl_TessLevelInner[0];
+#ifdef HIGH_TESSELLATION
+        float tessFactor = 64.0;
+#else
+        float tessFactor = 8.0;
+#endif
+
+        gl_TessLevelOuter[0] = tessFactor;
+        gl_TessLevelOuter[1] = tessFactor;
+        gl_TessLevelOuter[2] = tessFactor;
+        gl_TessLevelInner[0] = tessFactor;
+        gl_TessLevelInner[1] = tessFactor;
     }
 
     gl_out[gl_InvocationID].gl_Position = gl_in[gl_InvocationID].gl_Position;

--- a/Source/RenderManager.cpp
+++ b/Source/RenderManager.cpp
@@ -21,6 +21,7 @@ RenderManager::RenderManager()
     addShaderFeatureMenuItem(SF_Specular, "Specular Highlights");
     addShaderFeatureMenuItem(SF_Cutout, "Alpha Cutout");
     addShaderFeatureMenuItem(SF_Fog, "Fog");
+    addShaderFeatureMenuItem(SF_HighTessellation, "Extra Tessellation");
 
     // Set up menu items for showing debugging modes
     addDebugModeMenuItem(RenderDebugMode::None, "None");

--- a/Source/RenderManager.cpp
+++ b/Source/RenderManager.cpp
@@ -24,6 +24,7 @@ RenderManager::RenderManager()
 
     // Set up menu items for showing debugging modes
     addDebugModeMenuItem(RenderDebugMode::None, "None");
+    addDebugModeMenuItem(RenderDebugMode::Wireframe, "Wireframe");
     addDebugModeMenuItem(RenderDebugMode::Albedo, "Albedo");
     addDebugModeMenuItem(RenderDebugMode::Gloss, "Gloss");
     addDebugModeMenuItem(RenderDebugMode::Normals, "Normals");

--- a/Source/RenderManager.h
+++ b/Source/RenderManager.h
@@ -8,6 +8,7 @@
 enum class RenderDebugMode
 {
     None = 0,
+    Wireframe = SF_DebugWireframe,
     Albedo = SF_DebugGBufferAlbedo,
     Occlusion = SF_DebugGBufferOcclusion,
     Gloss = SF_DebugGBufferGloss,

--- a/Source/Renderer/Renderer.cpp
+++ b/Source/Renderer/Renderer.cpp
@@ -276,18 +276,14 @@ void Renderer::executeDeferredGBufferPass() const
 
     //Draw terrain
     terrainShader_->bindVariant(ALL_SHADER_FEATURES);
-    auto terrains = SceneManager::instance()->terrains();
-    for (unsigned int i = 0; i < terrains.size(); ++i)
+    for (Terrain* terrain : SceneManager::instance()->terrains())
     {
-        //Get the terrain element
-        auto terrain = terrains[i];
-
         //Set mesh and heightmap
         terrain->mesh()->bind();
         updateTerrainUniformBuffer(terrain);
 
-        // Render all the terrain tiles in one instanced draw call
-        glDrawElements(GL_TRIANGLES, terrain->mesh()->elementsCount(), GL_UNSIGNED_SHORT, (void*)0);
+        // Render the terrain with tessellation
+        glDrawElements(GL_PATCHES, terrain->mesh()->elementsCount(), GL_UNSIGNED_SHORT, (void*)0);
     }
 }
 

--- a/Source/Renderer/Renderer.cpp
+++ b/Source/Renderer/Renderer.cpp
@@ -185,9 +185,6 @@ void Renderer::updateTerrainUniformBuffer(const Terrain* terrain) const
     TerrainUniformData data;
     Vector3 dimens = terrain->gameObject()->terrain()->terrainDimensions();
     int layerCount = terrain->gameObject()->terrain()->layerCount();
-    Vector2 tileSize = terrain->gameObject()->terrain()->tileCount();
-    data.terrainTileCount[0] = (int)tileSize.x;
-    data.terrainTileCount[1] = (int)tileSize.y;
     data.terrainSize = Vector4(dimens.x, dimens.y, dimens.z, float(layerCount)); //layercount stored in w
     
     data.terrainTextureOffsetScale = Vector4(1.0f, 0.0f, 1.0f, 1.0f);
@@ -271,8 +268,7 @@ void Renderer::executeDeferredGBufferPass() const
         updateTerrainUniformBuffer(terrain);
 
         // Render all the terrain tiles in one instanced draw call
-        const int instanceCount = (int)(terrain->tileCount().x * terrain->tileCount().y);
-        glDrawElementsInstanced(GL_TRIANGLES, terrain->mesh()->elementsCount(), GL_UNSIGNED_SHORT, (void*)0, instanceCount);
+        glDrawElements(GL_TRIANGLES, terrain->mesh()->elementsCount(), GL_UNSIGNED_SHORT, (void*)0);
     }
 }
 

--- a/Source/Renderer/Renderer.cpp
+++ b/Source/Renderer/Renderer.cpp
@@ -56,6 +56,25 @@ void Renderer::renderFrame(const Camera* camera)
     updateSceneUniformBuffer();
     updateCameraUniformBuffer(camera);
 
+    // Wireframe debugging mode needs to be handled separately.
+    if(RenderManager::instance()->debugMode() == RenderDebugMode::Wireframe)
+    {
+        glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+
+        // We want to render directly to the target framebuffer
+        targetFramebuffer_->use();
+
+        // Normally, the guffer pass only needs to clear depth, not colour.
+        // When rendering a wireframe we need to clear the color too
+        glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+        executeDeferredGBufferPass();
+
+        // Ensure wireframe rendering is turned off again
+        glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+        return;
+    }
+
     // Ensure the gbuffer exists and is ok
     createGBuffer();
 

--- a/Source/Renderer/Shader.cpp
+++ b/Source/Renderer/Shader.cpp
@@ -194,6 +194,7 @@ std::string ShaderVariant::createFeatureDefines() const
     if (hasFeature(SF_Specular)) defines += "#define SPECULAR_ON \n";
     if (hasFeature(SF_Cutout)) defines += "#define ALPHA_TEST_ON \n";
     if (hasFeature(SF_Fog)) defines += "#define FOG_ON \n";
+    if (hasFeature(SF_HighTessellation)) defines += "#define HIGH_TESSELLATION \n";
     if (hasFeature(SF_DebugGBufferAlbedo)) defines += "#define DEBUG_GBUFFER_ALBEDO \n";
     if (hasFeature(SF_DebugGBufferOcclusion)) defines += "#define DEBUG_GBUFFER_OCCLUSION \n";
     if (hasFeature(SF_DebugGBufferNormals)) defines += "#define DEBUG_GBUFFER_NORMALS \n";

--- a/Source/Renderer/Shader.cpp
+++ b/Source/Renderer/Shader.cpp
@@ -74,6 +74,37 @@ ShaderVariant::ShaderVariant(ShaderFeatureList features, const std::string &orig
     program_ = glCreateProgram();
     glAttachShader(program_, vertexShader);
     glAttachShader(program_, fragmentShader);
+
+    // If detected in the source code, also compile a tessellation control shader
+    if (vertexSource.find("TESS_CONTROL_SHADER") != std::string::npos)
+    {
+        const std::string tessEvaluationSource = preprocessSource(GL_TESS_CONTROL_SHADER, originalSource);
+        GLuint tessEvaluationShader;
+        if (!compileShader(GL_TESS_CONTROL_SHADER, tessEvaluationSource.c_str(), tessEvaluationShader))
+        {
+            printf("Failed to compile tessellation control shader \n");
+        }
+        else
+        {
+            glAttachShader(program_, tessEvaluationShader);
+        }
+    }
+
+    // If detected in the source code, also compile a tessellation evaluation shader
+    if(vertexSource.find("TESS_EVALUATION_SHADER") != std::string::npos)
+    {
+        const std::string tessEvaluationSource = preprocessSource(GL_TESS_EVALUATION_SHADER, originalSource);
+        GLuint tessEvaluationShader;
+        if(!compileShader(GL_TESS_EVALUATION_SHADER, tessEvaluationSource.c_str(), tessEvaluationShader))
+        {
+            printf("Failed to compile tessellation evaluation shader \n");
+        }
+        else
+        {
+            glAttachShader(program_, tessEvaluationShader);
+        }
+    }
+
     glLinkProgram(program_);
 
     // We are using program id 0 to mean no program.
@@ -103,6 +134,9 @@ ShaderVariant::ShaderVariant(ShaderFeatureList features, const std::string &orig
 
     // Set texture locations
     setTextureLocation("_MainTexture", 0);
+
+    // Specify that tessellation is always on triangles (aka patches of 3)
+    glPatchParameteri(GL_PATCH_VERTICES, 3);
 }
 
 ShaderVariant::~ShaderVariant()
@@ -176,7 +210,8 @@ std::string ShaderVariant::preprocessSource(GLenum shaderStage, const std::strin
     finalSource += "#extension ARB_bindless_texture:require \n";
 
     // Next, add a stage-specific define
-    assert(shaderStage == GL_VERTEX_SHADER || shaderStage == GL_FRAGMENT_SHADER);
+    assert(shaderStage == GL_VERTEX_SHADER || shaderStage == GL_FRAGMENT_SHADER 
+        || shaderStage == GL_TESS_CONTROL_SHADER || shaderStage == GL_TESS_EVALUATION_SHADER);
     if (shaderStage == GL_VERTEX_SHADER)
     {
         finalSource += "#define VERTEX_SHADER 1 \n";
@@ -184,6 +219,14 @@ std::string ShaderVariant::preprocessSource(GLenum shaderStage, const std::strin
     else if (shaderStage == GL_FRAGMENT_SHADER)
     {
         finalSource += "#define FRAGMENT_SHADER 1 \n";
+    }
+    else if(shaderStage == GL_TESS_CONTROL_SHADER)
+    {
+        finalSource += "#define TESS_CONTROL_SHADER 1 \n";
+    }
+    else if(shaderStage == GL_TESS_EVALUATION_SHADER)
+    {
+        finalSource += "#define TESS_EVALUATION_SHADER 1 \n";
     }
 
     // Add feature-specific defines next in the file.

--- a/Source/Renderer/Shader.h
+++ b/Source/Renderer/Shader.h
@@ -18,6 +18,9 @@ enum ShaderFeature
 
     SF_Fog = 16,
 
+    // Wireframe rendering mode
+    SF_DebugWireframe = 128,
+
     // GBuffer debugging modes
     SF_DebugGBufferAlbedo = 256,
     SF_DebugGBufferOcclusion = 512,

--- a/Source/Renderer/Shader.h
+++ b/Source/Renderer/Shader.h
@@ -18,6 +18,9 @@ enum ShaderFeature
 
     SF_Fog = 16,
 
+    // Causes a large amount of tessellation to be used on the terrain
+    SF_HighTessellation = 32,
+
     // Wireframe rendering mode
     SF_DebugWireframe = 128,
 

--- a/Source/Renderer/UniformBuffer.h
+++ b/Source/Renderer/UniformBuffer.h
@@ -46,7 +46,6 @@ struct CameraUniformData
 
 struct TerrainUniformData
 {
-    int terrainTileCount[4];
     Vector4 terrainTextureOffsetScale;
     Vector4 terrainSize;
     Vector4 textureScale;

--- a/Source/Scene/Terrain.cpp
+++ b/Source/Scene/Terrain.cpp
@@ -25,16 +25,6 @@ Terrain::Terrain(GameObject* gameObject)
     terrainLayers_[2].slopeHardness = 0.25f;
 }
 
-Vector2 Terrain::tileCount()
-{
-    //Determine how big the mesh is in one direction
-    int meshDimension = sqrtf(mesh()->vertexCount() / 6);
-    //divide by the total size of the heightfield to determine the number of tiles
-
-    return Vector2((float)heightMap_->width()/meshDimension, (float)heightMap_->height()/meshDimension);
-}
-
-
 void Terrain::drawProperties()
 {
     ImGui::ResourceSelect<Texture>("Heightmap", "Select Heightmap", heightMap_);

--- a/Source/Scene/Terrain.h
+++ b/Source/Scene/Terrain.h
@@ -33,9 +33,6 @@ public:
     Mesh* mesh() const { return mesh_; }
     Texture* heightmap() const { return heightMap_; }
 
-    // Num of tiles in X and Y
-    Vector2 tileCount(); 
-
     // Total size of the terrain, in m, in X,Y,Z
     Vector3 terrainDimensions() const { return dimensions_; }
     


### PR DESCRIPTION
This pull request replaces the current instancing-based terrain rendering with an approach using tessellation. A low-polycount mesh is used for the terrain and Terrain.shader tessellates the mesh in areas close to the viewer. This has a huge performance benefit as a) less meshes are drawn and b) less triangles are drawn.

- Add support for compiling tessellation control shaders
- Add support for compiling tessellation evaluation shaders
- Add camera distance-based tessellation to Terrain.shader
- Add wireframe debug mode to view menu

Risk: Low
The changes are contained within the terrain rendering code and do not affect most of the application.