### PR TITLE
Terrain detail meshes

### DIFF
--- a/Engine.vcxproj
+++ b/Engine.vcxproj
@@ -148,6 +148,7 @@
     <None Include="Resources\Shaders\Includes\UniformBuffers.inc.shader" />
     <None Include="Resources\Shaders\SkyboxPass.shader" />
     <None Include="Resources\Shaders\Terrain.shader" />
+    <None Include="Resources\Shaders\TerrainDetail.shader" />
     <None Include="Resources\Shaders\Water.shader" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/Engine.vcxproj.filters
+++ b/Engine.vcxproj.filters
@@ -375,12 +375,15 @@
     </None>
     <None Include="Resources\Shaders\Water.shader">
       <Filter>Shaders</Filter>
-	</None>
+    </None>
     <None Include="Resources\Shaders\Includes\Atmosphere.inc.shader">
       <Filter>Shaders\Includes</Filter>
     </None>
     <None Include="Resources\Shaders\Sky\PrecomputeTransmittance.shader">
       <Filter>Shaders\Sky</Filter>
+    </None>
+    <None Include="Resources\Shaders\TerrainDetail.shader">
+      <Filter>Shaders</Filter>
     </None>
   </ItemGroup>
 </Project>

--- a/Resources/Materials/Terrain/detail_grass.material
+++ b/Resources/Materials/Terrain/detail_grass.material
@@ -1,0 +1,5 @@
+{
+    albedo_texture = Resources\Textures\detail_grass_albedo.tga
+    smoothness = 0
+    cutout = 1
+}

--- a/Resources/Meshes/grass.obj
+++ b/Resources/Meshes/grass.obj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4bf72fb3c7243772dcfd65386bf2d56c32590f05af738afa023ef3036a8ead4d
+size 1329

--- a/Resources/Meshes/grass.obj
+++ b/Resources/Meshes/grass.obj
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4bf72fb3c7243772dcfd65386bf2d56c32590f05af738afa023ef3036a8ead4d
-size 1329
+oid sha256:79f7a76d2c69a4bb3d6d9b270869d85e8facd5b6aa4dd2997abbd2c90433c8c7
+size 1581

--- a/Resources/Prefabs/Terrain.prefab
+++ b/Resources/Prefabs/Terrain.prefab
@@ -1,40 +1,48 @@
 {
     name = Terrain
     Terrain {
-        dimensions = 2048 168 2048
-        water_depth = 16.9
+        dimensions = 1024 144 1024
+        water_color = 0.0214742 0.0279743 0.0389375 1
+        water_depth = 7
         layers::0 {
             altitude_border = 35
             altitude_transition = 4
             slope_border = 0.65
             slope_hardness = 0.141
-            texture_tile_size = 20 20
+            texture_tile_size = 15 15
             material = Resources\Materials\ground_rock_01.material
         }
         layers::1 {
+            altitude_border = 4.2
+            altitude_transition = 0.7
             slope_border = 0.79
             slope_hardness = 0.46
             texture_tile_size = 20 20
             material = Resources\Materials\ground_grass_01.material
         }
         layers::2 {
-            altitude_border = 109.4
-            altitude_transition = 20
+            altitude_border = 54.6
+            altitude_transition = 10
             slope_border = 0.5
             slope_hardness = 0.341
             texture_tile_size = 30 30
             material = Resources\Materials\ground_snow.material
         }
         layers::3 {
-            altitude_border = 9.5
-            altitude_transition = -6
-            texture_tile_size = 30 30
+            altitude_border = 4.4
+            altitude_transition = -2
+            texture_tile_size = 4 4
             material = Resources\Materials\ground_sand.material
         }
         seed = 3465
-        factal_smoothness = 2.11
-        mountain_scale = 8.8
-        island_factor = 1
+        factal_smoothness = 1.99
+        mountain_scale = 6.9
+        island_factor = 8.45
+        detail_mesh = Resources\Meshes\grass.obj
+        detail_material = Resources\Materials\Terrain\detail_grass.material
+        detail_scale = 1.9 2.6
+        detail_altitude_limits = 4.5 38.5
+        detail_slope_limit = 0.5
     }
     Transform {
     }

--- a/Resources/Scenes/startup.scene
+++ b/Resources/Scenes/startup.scene
@@ -1,35 +1,6 @@
 {
     gameobjects::0 {
         prefab = Resources\Prefabs\Terrain.prefab
-        Terrain {
-            dimensions = 1024 144 1024
-            water_color = 0.0214742 0.0279743 0.0389375 1
-            water_depth = 7
-            layers::0 {
-                texture_tile_size = 15 15
-            }
-            layers::1 {
-                altitude_border = 4.2
-                altitude_transition = 0.7
-            }
-            layers::2 {
-                altitude_border = 54.6
-                altitude_transition = 10
-            }
-            layers::3 {
-                altitude_border = 4.4
-                altitude_transition = -2
-                texture_tile_size = 4 4
-            }
-            factal_smoothness = 1.99
-            mountain_scale = 6.9
-            island_factor = 8.45
-            detail_mesh = Resources\Meshes\grass.obj
-            detail_material = Resources\Materials\Terrain\detail_grass.material
-            detail_scale = 1.9 2.6
-            detail_altitude_limits = 4.5 38.5
-            detail_slope_limit = 0.5
-        }
     }
     sun_intensity = 4.4
     sun_rotation = 16 140

--- a/Resources/Scenes/startup.scene
+++ b/Resources/Scenes/startup.scene
@@ -24,9 +24,6 @@
                 altitude_border = 4.4
                 altitude_transition = -2
                 texture_tile_size = 4 4
-                detail_mesh = Resources\Meshes\sand_debris.obj
-                detail_material = Resources\Materials\ground_sand.material
-                detail_scale = 0 0.5
             }
             factal_smoothness = 1.99
             mountain_scale = 6.9

--- a/Resources/Scenes/startup.scene
+++ b/Resources/Scenes/startup.scene
@@ -2,9 +2,37 @@
     gameobjects::0 {
         prefab = Resources\Prefabs\Terrain.prefab
         Terrain {
-            dimensions = 2048 265 2048
+            dimensions = 1024 144 1024
             water_color = 0.0214742 0.0279743 0.0389375 1
             water_depth = 7
+            water_depth = 7.6
+            layers::0 {
+                texture_tile_size = 15 15
+            }
+            layers::1 {
+                altitude_border = 4.2
+                altitude_transition = 0.7
+                detail_mesh = Resources\Meshes\grass.obj
+                detail_material = Resources\Materials\Terrain\detail_grass.material
+                detail_scale = 1 1.7
+            }
+            layers::2 {
+                altitude_border = 55
+                altitude_transition = 10
+            }
+            layers::3 {
+                altitude_border = 4.4
+                altitude_transition = -2
+                texture_tile_size = 4 4
+                detail_mesh = Resources\Meshes\sand_debris.obj
+                detail_material = Resources\Materials\ground_sand.material
+                detail_scale = 0 0.5
+            }
+            factal_smoothness = 1.99
+            mountain_scale = 6.9
+            island_factor = 8.45
+        }
+    }
         }
     }
     ambient_light = 0.192568 0.238955 0.333663 1

--- a/Resources/Scenes/startup.scene
+++ b/Resources/Scenes/startup.scene
@@ -14,7 +14,7 @@
                 altitude_transition = 0.7
                 detail_mesh = Resources\Meshes\grass.obj
                 detail_material = Resources\Materials\Terrain\detail_grass.material
-                detail_scale = 1 1.7
+                detail_scale = 1.3 2.2
             }
             layers::2 {
                 altitude_border = 55

--- a/Resources/Scenes/startup.scene
+++ b/Resources/Scenes/startup.scene
@@ -5,19 +5,15 @@
             dimensions = 1024 144 1024
             water_color = 0.0214742 0.0279743 0.0389375 1
             water_depth = 7
-            water_depth = 7.6
             layers::0 {
                 texture_tile_size = 15 15
             }
             layers::1 {
                 altitude_border = 4.2
                 altitude_transition = 0.7
-                detail_mesh = Resources\Meshes\grass.obj
-                detail_material = Resources\Materials\Terrain\detail_grass.material
-                detail_scale = 1.3 2.2
             }
             layers::2 {
-                altitude_border = 55
+                altitude_border = 54.6
                 altitude_transition = 10
             }
             layers::3 {
@@ -28,15 +24,15 @@
             factal_smoothness = 1.99
             mountain_scale = 6.9
             island_factor = 8.45
+            detail_mesh = Resources\Meshes\grass.obj
+            detail_material = Resources\Materials\Terrain\detail_grass.material
+            detail_scale = 1.9 2.6
+            detail_altitude_limits = 4.5 38.5
+            detail_slope_limit = 0.5
         }
     }
-        }
-    }
-    ambient_light = 0.192568 0.238955 0.333663 1
-    ambient_intensity = 1.55
-    sun_intensity = 5.8
-    sun_rotation = 25 95
-    sun_rotation = 22 165
-    fog_density = 0.007
-    fog_height_falloff = 0.042
+    sun_intensity = 4.4
+    sun_rotation = 16 140
+    fog_density = 0.016
+    fog_height_falloff = 0.036
 }

--- a/Resources/Shaders/Deferred-Debug.shader
+++ b/Resources/Shaders/Deferred-Debug.shader
@@ -43,6 +43,11 @@ void main()
 #ifdef DEBUG_GBUFFER_OCCLUSION
     fragColor = vec4(surface.occlusion);
 #endif
+    
+    // Translucency mode
+#ifdef DEBUG_GBUFFER_TRANSLUCENCY
+    fragColor = vec4(surface.translucency);
+#endif
 
     // Shadows mode
 #ifdef DEBUG_SHADOWS

--- a/Resources/Shaders/Deferred-Lighting.shader
+++ b/Resources/Shaders/Deferred-Lighting.shader
@@ -36,6 +36,12 @@ void main()
     vec3 ambientLight = surface.diffuseColor * _AmbientColor.rgb;
     vec3 directLight = PhysicallyBasedBRDF(surface, sunColor, sunDir, viewDir);
 
+    // Add translucent lighting
+    // "Vegetation Procedural Animation and Shading in Crysis" [Sousa08] suggested adding a term based on -N.L
+#ifdef TRANSLUCENCY_ON
+    directLight += max(0.0, dot(-surface.worldNormal, sunDir)) * sunColor * surface.diffuseColor * surface.translucency;
+#endif
+
     // Attenuate the direct light by a shadow factor
 #ifdef SHADOWS_ON
     directLight *= SampleSunShadow(worldPosition, viewDistance);

--- a/Resources/Shaders/Includes/Common.inc.shader
+++ b/Resources/Shaders/Includes/Common.inc.shader
@@ -11,6 +11,7 @@ struct SurfaceProperties
     vec3 diffuseColor;
     float occlusion;
     float gloss;
+    float translucency;
     vec3 worldNormal;
 };
 

--- a/Resources/Shaders/Includes/DeferredGBuffer.inc.shader
+++ b/Resources/Shaders/Includes/DeferredGBuffer.inc.shader
@@ -23,7 +23,7 @@ SurfaceProperties unpackGBuffer(vec4 gbuffer0, vec4 gbuffer1)
     surface.occlusion = 1.0;
     surface.gloss = gbuffer0.a;
     surface.translucency = gbuffer1.a;
-    surface.worldNormal = gbuffer1.xyz * 2.0 - 1.0;
+    surface.worldNormal = normalize(gbuffer1.xyz * 2.0 - 1.0);
     return surface;
 }
 

--- a/Resources/Shaders/Includes/DeferredGBuffer.inc.shader
+++ b/Resources/Shaders/Includes/DeferredGBuffer.inc.shader
@@ -6,13 +6,13 @@
 
 // GBuffer Layout
 // RT0: Albedo (RGB), Gloss (A)
-// RT1: Normals (XYZ, 10 bits), Unused (A, 2 bits)
+// RT1: Normals (XYZ, 10 bits), Translucency (a, 2 bits)
 
 // Stores surface properties into the gbuffer format
 void packGBuffer(SurfaceProperties surface, out vec4 gbuffer0, out vec4 gbuffer1)
 {
     gbuffer0 = vec4(surface.diffuseColor, surface.gloss);
-    gbuffer1 = vec4(surface.worldNormal * 0.5 + 0.5, 0.0);
+    gbuffer1 = vec4(surface.worldNormal * 0.5 + 0.5, surface.translucency);
 }
 
 // Retrieves surface properties from the gbuffer format
@@ -22,6 +22,7 @@ SurfaceProperties unpackGBuffer(vec4 gbuffer0, vec4 gbuffer1)
     surface.diffuseColor = gbuffer0.rgb;
     surface.occlusion = 1.0;
     surface.gloss = gbuffer0.a;
+    surface.translucency = gbuffer1.a;
     surface.worldNormal = gbuffer1.xyz * 2.0 - 1.0;
     return surface;
 }

--- a/Resources/Shaders/Includes/UniformBuffers.inc.shader
+++ b/Resources/Shaders/Includes/UniformBuffers.inc.shader
@@ -72,5 +72,13 @@ layout(std140, binding = 5) uniform terrain_data
     sampler2D _TerrainNormalMapTextures[MAX_TERRAIN_LAYERS];
 };
 
+// Terrain details uniform buffer.
+// The buffer is updated once per details batch.
+layout(std140, binding = 6) uniform terrain_details_data
+{
+    // World-space offsets for each terrain detail.
+    // Once per detail mesh instance, up to 1024 in total.
+    uniform vec4 _TerrainDetailPositions[1024];
+};
 
 #endif // UNIFORM_BUFFERS_INCLUDED

--- a/Resources/Shaders/Standard.shader
+++ b/Resources/Shaders/Standard.shader
@@ -65,6 +65,7 @@ void main()
 {
     SurfaceProperties surface;
     surface.occlusion = 1.0;
+    surface.translucency = 0.0;
 
     // Sample the albedo texture for the diffuse color
 #ifdef TEXTURE_ON

--- a/Resources/Shaders/Terrain.shader
+++ b/Resources/Shaders/Terrain.shader
@@ -193,6 +193,7 @@ void main()
     surface.diffuseColor = albedoSmoothness.rgb;
     surface.gloss = albedoSmoothness.a;
     surface.occlusion = 1.0;
+    surface.translucency = 0.0;
 
 #ifdef NORMAL_MAP_ON
     surface.worldNormal.x = dot(tangentNormal, tangentToWorld[0]);

--- a/Resources/Shaders/TerrainDetail.shader
+++ b/Resources/Shaders/TerrainDetail.shader
@@ -33,6 +33,11 @@ void main()
     float scale = instanceOffsetScale.a;
     vec3 worldPosition = (localPosition * scale) + offset;
 
+    // Apply a wind offset to the world position
+    float offsetMagnitude = sin(_Time.x * 1.5 + dot(worldPosition, vec3(0.2))) * _position.y;
+    vec2 offsetDir = vec2(0.3, 0.2);
+    worldPosition.xz += offsetDir * offsetMagnitude;
+
     // Project the world position to clip space
     gl_Position = _ViewProjectionMatrix * vec4(worldPosition, 1.0);
 

--- a/Resources/Shaders/TerrainDetail.shader
+++ b/Resources/Shaders/TerrainDetail.shader
@@ -86,7 +86,7 @@ void main()
     surface.gloss = _Color.a;
 
     // Make grass partially translucent
-    surface.translucency = 0.666;
+    surface.translucency = 0.333;
 
     // Grass doesn't use normal mapping
     surface.worldNormal = worldNormal;

--- a/Resources/Shaders/TerrainDetail.shader
+++ b/Resources/Shaders/TerrainDetail.shader
@@ -86,7 +86,12 @@ void main()
     surface.gloss = _Color.a;
 
     // Make grass partially translucent
+#ifdef TEXTURE_ON
+    // Use the a to make the grass more translucent at the edge
+    surface.translucency = mix(0.333, 1.0, 1.0 - diffuseAlpha.a);
+#else
     surface.translucency = 0.333;
+#endif
 
     // Grass doesn't use normal mapping
     surface.worldNormal = worldNormal;

--- a/Resources/Shaders/TerrainDetail.shader
+++ b/Resources/Shaders/TerrainDetail.shader
@@ -102,6 +102,9 @@ void main()
     // The a channel is used for opacity, so always use a constant gloss term.
     surface.gloss = _Color.a;
 
+    // Make grass partially translucent
+    surface.translucency = 0.5;
+
     // Grass doesn't use normal mapping
     surface.worldNormal = worldNormal;
 

--- a/Resources/Shaders/TerrainDetail.shader
+++ b/Resources/Shaders/TerrainDetail.shader
@@ -1,0 +1,107 @@
+
+#include "UniformBuffers.inc.shader"
+
+#define USE_GBUFFER_WRITE
+#include "Deferred.inc.shader"
+
+#ifdef VERTEX_SHADER
+
+layout(binding = 8) uniform sampler2D _TerrainHeightmap;
+
+layout(location = 0) in vec4 _position;
+layout(location = 3) in vec2 _texcoord;
+
+out vec3 worldNormal;
+out vec2 texcoord;
+
+void main()
+{
+    // Rotate the local position pseudo-randomly
+    // Just base the rotation on the instance id
+    float rotationRad = float(gl_InstanceID) * 0.1;
+    float sinRotation = sin(rotationRad);
+    float cosRotation = cos(rotationRad);
+    vec3 localPosition = vec3(
+        _position.x * cosRotation - _position.z * sinRotation,
+        _position.y,
+        _position.x * sinRotation + _position.z * cosRotation
+    );
+
+    // Apply the scale and offset to the local-space position
+    vec4 instanceOffsetScale = _TerrainDetailPositions[gl_InstanceID];
+    vec3 offset = instanceOffsetScale.xyz;
+    float scale = instanceOffsetScale.a;
+    vec3 worldPosition = (localPosition * scale) + offset;
+
+    // Project the world position to clip space
+    gl_Position = _ViewProjectionMatrix * vec4(worldPosition, 1.0);
+
+    vec3 normalizedPosition = worldPosition / _TerrainSize.xyz;
+
+    // Compute the offset from the normalized position to get the adjacent heightmap pixels
+    ivec2 heightmapRes = textureSize(_TerrainHeightmap, 0);
+    vec2 heightmapTexelSize = 1.0 / heightmapRes;
+
+    // Determine the gradient along x and z at the vertex position
+    float x1 = texture(_TerrainHeightmap, normalizedPosition.xz + heightmapTexelSize * vec2(-1.0, 0.0)).r;
+    float x2 = texture(_TerrainHeightmap, normalizedPosition.xz + heightmapTexelSize * vec2(1.0, 0.0)).r;
+    float z1 = texture(_TerrainHeightmap, normalizedPosition.xz + heightmapTexelSize * vec2(0.0, -1.0)).r;
+    float z2 = texture(_TerrainHeightmap, normalizedPosition.xz + heightmapTexelSize * vec2(0.0, 1.0)).r;
+    float dydx = x2 - x1;
+    float dydz = z2 - z1;
+    dydx *= _TerrainSize.y;
+    dydz *= _TerrainSize.y;
+    dydx /= (2.0 * heightmapTexelSize.x) * _TerrainSize.x;
+    dydz /= (2.0 * heightmapTexelSize.y) * _TerrainSize.z;
+
+    // Determine the tangents along the X and Z
+    vec3 worldTangent = normalize(vec3(1.0, dydx, 0.0));
+    vec3 worldBitangent = normalize(vec3(0.0, dydz, 1.0));
+
+    // Cross product to get the world normal
+    worldNormal = cross(worldBitangent, worldTangent);
+
+    // Texcoord does not need to be modified.
+    texcoord = _texcoord;
+}
+
+#endif // VERTEX_SHADER
+
+#ifdef FRAGMENT_SHADER
+
+in vec3 worldNormal;
+in vec2 texcoord;
+
+void main()
+{
+    SurfaceProperties surface;
+    surface.occlusion = 1.0;
+
+    // Sample the albedo texture for the diffuse color
+#ifdef TEXTURE_ON
+    vec4 diffuseAlpha = texture(_AlbedoTexture, texcoord);
+    surface.diffuseColor = diffuseAlpha.rgb * _Color.rgb;
+
+#ifdef ALPHA_TEST_ON
+    // Use alpha test rendering
+    if (diffuseAlpha.a < 0.5)
+    {
+        discard;
+    }
+#endif
+
+#else
+    surface.diffuseColor = _Color.rgb;
+#endif
+
+    // The a channel is used for opacity, so always use a constant gloss term.
+    surface.gloss = _Color.a;
+
+    // Grass doesn't use normal mapping
+    surface.worldNormal = worldNormal;
+
+    // Output surface properties to the gbuffer
+    writeToGBuffer(surface);
+}
+
+#endif // FRAGMENT_SHADER

--- a/Resources/Shaders/TerrainDetail.shader
+++ b/Resources/Shaders/TerrainDetail.shader
@@ -36,7 +36,7 @@ void main()
 
     // Apply a wind offset to the world position
     float offsetMagnitude = sin(_Time.x * 1.5 + dot(worldPosition, vec3(0.2))) * _position.y;
-    vec2 offsetDir = vec2(0.3, 0.2);
+    vec2 offsetDir = vec2(0.45, 0.2);
     worldPosition.xz += offsetDir * offsetMagnitude;
 
     // Project the world position to clip space

--- a/Resources/Textures/detail_grass_albedo.tga
+++ b/Resources/Textures/detail_grass_albedo.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a3bf845309ff901a3a4bcd29b0c1517a371f0e8c024f2bdcce5fb64549d59d9
+size 4194348

--- a/Resources/Textures/detail_grass_albedo.tga
+++ b/Resources/Textures/detail_grass_albedo.tga
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6a3bf845309ff901a3a4bcd29b0c1517a371f0e8c024f2bdcce5fb64549d59d9
+oid sha256:d6606cd39b10cb4ed9604666a27e7662ecdc2afe4271301d8024276783bb64c5
 size 4194348

--- a/Source/Math/Bounds.cpp
+++ b/Source/Math/Bounds.cpp
@@ -2,6 +2,13 @@
 
 #include <algorithm>
 
+Bounds::Bounds()
+    : min_(Point3::origin()),
+    max_(Point3::origin())
+{
+
+}
+
 Bounds::Bounds(const Point3& min, const Point3& max)
     : min_(min),
     max_(max)

--- a/Source/Math/Bounds.h
+++ b/Source/Math/Bounds.h
@@ -6,6 +6,7 @@
 class Bounds
 {
 public:
+    Bounds();
     Bounds(const Point3 &min, const Point3 &max);
 
     // Covered region

--- a/Source/RenderManager.cpp
+++ b/Source/RenderManager.cpp
@@ -35,6 +35,7 @@ RenderManager::RenderManager()
     addDebugModeMenuItem(RenderDebugMode::Gloss, "Gloss");
     addDebugModeMenuItem(RenderDebugMode::Normals, "Normals");
     addDebugModeMenuItem(RenderDebugMode::Occlusion, "Occlusion");
+    addDebugModeMenuItem(RenderDebugMode::Translucency, "Translucency");
     addDebugModeMenuItem(RenderDebugMode::Shadows, "Shadows");
     addDebugModeMenuItem(RenderDebugMode::ShadowCascades, "Shadow Cascades");
 }

--- a/Source/RenderManager.cpp
+++ b/Source/RenderManager.cpp
@@ -25,6 +25,7 @@ RenderManager::RenderManager()
     addShaderFeatureMenuItem(SF_SoftShadows, "Soft Shadows");
     addShaderFeatureMenuItem(SF_ShadowCascadeBlending, "Shadow Cascade Blending");
     addShaderFeatureMenuItem(SF_HighTessellation, "Extra Tessellation");
+    addShaderFeatureMenuItem(SF_TerrainDetailMeshes, "Terrain Details");
 
     // Set up menu items for showing debugging modes
     addDebugModeMenuItem(RenderDebugMode::None, "None");

--- a/Source/RenderManager.cpp
+++ b/Source/RenderManager.cpp
@@ -26,6 +26,7 @@ RenderManager::RenderManager()
     addShaderFeatureMenuItem(SF_ShadowCascadeBlending, "Shadow Cascade Blending");
     addShaderFeatureMenuItem(SF_HighTessellation, "Extra Tessellation");
     addShaderFeatureMenuItem(SF_TerrainDetailMeshes, "Terrain Details");
+    addShaderFeatureMenuItem(SF_ExtraTerrainDetails, "Extra Terrain Details");
     addShaderFeatureMenuItem(SF_Translucency, "Translucency");
 
     // Set up menu items for showing debugging modes

--- a/Source/RenderManager.cpp
+++ b/Source/RenderManager.cpp
@@ -26,6 +26,7 @@ RenderManager::RenderManager()
     addShaderFeatureMenuItem(SF_ShadowCascadeBlending, "Shadow Cascade Blending");
     addShaderFeatureMenuItem(SF_HighTessellation, "Extra Tessellation");
     addShaderFeatureMenuItem(SF_TerrainDetailMeshes, "Terrain Details");
+    addShaderFeatureMenuItem(SF_Translucency, "Translucency");
 
     // Set up menu items for showing debugging modes
     addDebugModeMenuItem(RenderDebugMode::None, "None");

--- a/Source/RenderManager.h
+++ b/Source/RenderManager.h
@@ -12,6 +12,7 @@ enum class RenderDebugMode
     Depth = SF_DebugGBufferDepth,
     Albedo = SF_DebugGBufferAlbedo,
     Occlusion = SF_DebugGBufferOcclusion,
+    Translucency = SF_DebugGBufferTranslucency,
     Gloss = SF_DebugGBufferGloss,
     Normals = SF_DebugGBufferNormals,
     Shadows = SF_DebugShadows,

--- a/Source/Renderer/Material.cpp
+++ b/Source/Renderer/Material.cpp
@@ -21,6 +21,7 @@ void Material::serialize(PropertyTable& table)
     table.serialize("albedo_texture", albedoTexture_, (ResourcePPtr<Texture>)nullptr);
     table.serialize("normal_map_texture", normalMapTexture_, (ResourcePPtr<Texture>)nullptr);
     table.serialize("smoothness", smoothness_, 0.5f);
+    table.serialize("cutout", cutout_, false);
 }
 
 void Material::drawEditor()
@@ -29,6 +30,7 @@ void Material::drawEditor()
     ImGui::ResourceSelect("Albedo", "Select Albedo Texture", albedoTexture_);
     ImGui::ResourceSelect("Normal Map", "Select Normal Map Texture", normalMapTexture_);
     ImGui::SliderFloat("Smoothness", &smoothness_, 0.0f, 1.0f);
+    ImGui::Checkbox("Cutout", &cutout_);
 }
 
 void Material::setColor(const Color& color)
@@ -51,6 +53,11 @@ void Material::setSmoothness(float smoothness)
     smoothness_ = smoothness;
 }
 
+void Material::setCutout(bool cutout)
+{
+    cutout_ = cutout;
+}
+
 ShaderFeatureList Material::supportedFeatures() const
 {
     // Start with no features
@@ -66,6 +73,12 @@ ShaderFeatureList Material::supportedFeatures() const
     if(normalMapTexture_ != nullptr)
     {
         features |= SF_NormalMap;
+    }
+
+    // Enable alpha testing if the cutout flag is set
+    if(cutout_)
+    {
+        features |= SF_Cutout;
     }
 
     return features;

--- a/Source/Renderer/Material.h
+++ b/Source/Renderer/Material.h
@@ -24,12 +24,14 @@ public:
     Texture* albedoTexture() const { return albedoTexture_; }
     Texture* normalMapTexture() const { return normalMapTexture_; }
     float smoothness() const { return smoothness_; }
+    bool cutout() const { return cutout_; }
 
     // Sets basic material settings
     void setColor(const Color &color);
     void setAlbedoTexture(Texture* albedoTexture);
     void setNormalMapTexture(Texture* normalMapTexture);
     void setSmoothness(float smoothness);
+    void setCutout(bool cutout);
 
     // Computes the set of enabled shader features, based on material settings
     ShaderFeatureList supportedFeatures() const;
@@ -39,4 +41,5 @@ private:
     Texture* albedoTexture_;
     Texture* normalMapTexture_;
     float smoothness_;
+    bool cutout_;
 };

--- a/Source/Renderer/Renderer.cpp
+++ b/Source/Renderer/Renderer.cpp
@@ -307,10 +307,11 @@ void Renderer::executeGeometryPass(const Camera* camera, ShaderFeatureList shade
 
         // Render each terrain details batch
         const Point3 cameraPosition = camera->gameObject()->transform()->positionWorld();
+        const float distanceScale = RenderManager::instance()->isFeatureGloballyEnabled(SF_ExtraTerrainDetails) ? 6.0f : 1.0f;
         for(const DetailBatch& batch : terrain->detailBatches())
         {
             // Skip batches that are further than the draw distance
-            if((batch.bounds.centre() - cameraPosition).sqrMagnitude() > batch.drawDistance * batch.drawDistance)
+            if((batch.bounds.centre() - cameraPosition).sqrMagnitude() > batch.drawDistance * batch.drawDistance * distanceScale)
             {
                 continue;
             }

--- a/Source/Renderer/Renderer.cpp
+++ b/Source/Renderer/Renderer.cpp
@@ -250,6 +250,13 @@ void Renderer::updateTerrainUniformBuffer(const Terrain* terrain) const
     terrainUniformBuffer_.update(data);
 }
 
+void Renderer::updateTerrainDetailsUniformBuffer(const DetailBatch& details) const
+{
+    TerrainDetailsData detailsData;
+    std::memcpy(detailsData.detailPositions, details.instancePositions, sizeof(Vector4) * details.count);
+    terrainDetailsUniformBuffer_.update(detailsData);
+}
+
 void Renderer::executeGeometryPass(const Camera* camera, ShaderFeatureList shaderFeatures) const
 {
     updateCameraUniformBuffer(camera);
@@ -328,10 +335,8 @@ void Renderer::executeGeometryPass(const Camera* camera, ShaderFeatureList shade
                 continue;
             }
 
-            TerrainDetailsData detailsData;
-            std::memcpy(detailsData.detailPositions, batch.instancePositions, sizeof(Vector4) * batch.count);
-            terrainDetailsUniformBuffer_.update(detailsData);
-
+            // Draw the batch data using an instanced draw call
+            updateTerrainDetailsUniformBuffer(batch);
             glDrawElementsInstanced(GL_TRIANGLES, elementsCount, GL_UNSIGNED_SHORT, (void*)0, batch.count);
         }
     }

--- a/Source/Renderer/Renderer.cpp
+++ b/Source/Renderer/Renderer.cpp
@@ -286,7 +286,7 @@ void Renderer::executeGeometryPass(const Camera* camera, ShaderFeatureList shade
 
     // Draw terrain
     const Terrain* terrain = SceneManager::instance()->terrain();
-    if(terrain != nullptr)
+    if (terrain != nullptr)
     {
         terrainShader_->bindVariant(shaderFeatures);
 
@@ -297,7 +297,11 @@ void Renderer::executeGeometryPass(const Camera* camera, ShaderFeatureList shade
 
         // Render the terrain with tessellation
         glDrawElements(GL_PATCHES, terrain->mesh()->elementsCount(), GL_UNSIGNED_SHORT, (void*)0);
+    }
 
+    // Draw terrain details
+    if(terrain != nullptr && RenderManager::instance()->isFeatureGloballyEnabled(SF_TerrainDetailMeshes))
+    {
         // Render each terrain details batch
         const Point3 cameraPosition = camera->gameObject()->transform()->positionWorld();
         for(const DetailBatch& batch : terrain->detailBatches())

--- a/Source/Renderer/Renderer.cpp
+++ b/Source/Renderer/Renderer.cpp
@@ -299,8 +299,15 @@ void Renderer::executeGeometryPass(const Camera* camera, ShaderFeatureList shade
         glDrawElements(GL_PATCHES, terrain->mesh()->elementsCount(), GL_UNSIGNED_SHORT, (void*)0);
 
         // Render each terrain details batch
+        const Point3 cameraPosition = camera->gameObject()->transform()->positionWorld();
         for(const DetailBatch& batch : terrain->detailBatches())
         {
+            // Skip batches that are further than the draw distance
+            if((batch.bounds.centre() - cameraPosition).sqrMagnitude() > batch.drawDistance * batch.drawDistance)
+            {
+                continue;
+            }
+
             batch.mesh->bind();
 
             // Gather the new contents of the per-draw buffer

--- a/Source/Renderer/Renderer.h
+++ b/Source/Renderer/Renderer.h
@@ -76,7 +76,7 @@ private:
     // Methods for updating the contents of uniform buffers
     void updateSceneUniformBuffer() const;
     void updateCameraUniformBuffer(const Camera* camera) const;
-    void updatePerDrawUniformBuffer(const StaticMesh* draw, const Texture* albedoTexture, const Texture* normalMapTexture) const;
+    void updatePerDrawUniformBuffer(const Matrix4x4 &localToWorld, const Material* material) const;
     void updateTerrainUniformBuffer(const Terrain* terrain) const;
 
     // Renders a full geometry pass using the specified camera

--- a/Source/Renderer/Renderer.h
+++ b/Source/Renderer/Renderer.h
@@ -45,10 +45,12 @@ private:
     UniformBuffer<CameraUniformData> cameraUniformBuffer_;
     UniformBuffer<PerDrawUniformData> perDrawUniformBuffer_;
     UniformBuffer<TerrainUniformData> terrainUniformBuffer_;
+    UniformBuffer<TerrainDetailsData> terrainDetailsUniformBuffer_;
 
     // Shaders used for gbuffer pass
     ResourcePPtr<Shader> standardShader_;
     ResourcePPtr<Shader> terrainShader_;
+    ResourcePPtr<Shader> terrainDetailMeshShader_;
 
     // Shaders used for deferred passes
     ResourcePPtr<Shader> deferredLightingShader_;

--- a/Source/Renderer/Renderer.h
+++ b/Source/Renderer/Renderer.h
@@ -78,6 +78,7 @@ private:
     void updateCameraUniformBuffer(const Camera* camera) const;
     void updatePerDrawUniformBuffer(const Matrix4x4 &localToWorld, const Material* material) const;
     void updateTerrainUniformBuffer(const Terrain* terrain) const;
+    void updateTerrainDetailsUniformBuffer(const DetailBatch& details) const;
 
     // Renders a full geometry pass using the specified camera
     void executeGeometryPass(const Camera* camera, ShaderFeatureList shaderFeatures) const;

--- a/Source/Renderer/Shader.cpp
+++ b/Source/Renderer/Shader.cpp
@@ -193,6 +193,7 @@ std::string ShaderVariant::createFeatureDefines() const
     if (hasFeature(SF_DebugGBufferDepth)) defines += "#define DEBUG_GBUFFER_DEPTH \n";
     if (hasFeature(SF_DebugGBufferAlbedo)) defines += "#define DEBUG_GBUFFER_ALBEDO \n";
     if (hasFeature(SF_DebugGBufferOcclusion)) defines += "#define DEBUG_GBUFFER_OCCLUSION \n";
+    if (hasFeature(SF_DebugGBufferTranslucency)) defines += "#define DEBUG_GBUFFER_TRANSLUCENCY \n";
     if (hasFeature(SF_DebugGBufferNormals)) defines += "#define DEBUG_GBUFFER_NORMALS \n";
     if (hasFeature(SF_DebugGBufferGloss)) defines += "#define DEBUG_GBUFFER_GLOSS \n";
     if (hasFeature(SF_DebugShadows)) defines += "#define DEBUG_SHADOWS \n";

--- a/Source/Renderer/Shader.cpp
+++ b/Source/Renderer/Shader.cpp
@@ -190,6 +190,7 @@ std::string ShaderVariant::createFeatureDefines() const
     if (hasFeature(SF_Shadows)) defines += "#define SHADOWS_ON \n";
     if (hasFeature(SF_SoftShadows)) defines += "#define SOFT_SHADOWS \n";
     if (hasFeature(SF_ShadowCascadeBlending)) defines += "#define SHADOW_CASCADE_BLENDING \n";
+    if (hasFeature(SF_Translucency)) defines += "#define TRANSLUCENCY_ON \n";
     if (hasFeature(SF_DebugGBufferDepth)) defines += "#define DEBUG_GBUFFER_DEPTH \n";
     if (hasFeature(SF_DebugGBufferAlbedo)) defines += "#define DEBUG_GBUFFER_ALBEDO \n";
     if (hasFeature(SF_DebugGBufferOcclusion)) defines += "#define DEBUG_GBUFFER_OCCLUSION \n";

--- a/Source/Renderer/Shader.h
+++ b/Source/Renderer/Shader.h
@@ -33,6 +33,9 @@ enum ShaderFeature
     // Enables detail meshes on the terrain
     SF_TerrainDetailMeshes = 65536,
 
+    // Enables computation of translucency lighting
+    SF_Translucency = 262144,
+
     // GBuffer debugging modes
     SF_DebugGBufferDepth = 32768,
     SF_DebugGBufferAlbedo = 256,

--- a/Source/Renderer/Shader.h
+++ b/Source/Renderer/Shader.h
@@ -37,6 +37,7 @@ enum ShaderFeature
     SF_DebugGBufferDepth = 32768,
     SF_DebugGBufferAlbedo = 256,
     SF_DebugGBufferOcclusion = 512,
+    SF_DebugGBufferTranslucency = 131072,
     SF_DebugGBufferNormals = 1024,
     SF_DebugGBufferGloss = 2048,
 

--- a/Source/Renderer/Shader.h
+++ b/Source/Renderer/Shader.h
@@ -33,6 +33,9 @@ enum ShaderFeature
     // Enables detail meshes on the terrain
     SF_TerrainDetailMeshes = 65536,
 
+    // Increases the terrain details draw distance
+    SF_ExtraTerrainDetails = 524288,
+
     // Enables computation of translucency lighting
     SF_Translucency = 262144,
 

--- a/Source/Renderer/Shader.h
+++ b/Source/Renderer/Shader.h
@@ -30,6 +30,9 @@ enum ShaderFeature
     // Enables a smooth transition between shadow map cascades.
     SF_ShadowCascadeBlending = 32768,
 
+    // Enables detail meshes on the terrain
+    SF_TerrainDetailMeshes = 65536,
+
     // GBuffer debugging modes
     SF_DebugGBufferDepth = 32768,
     SF_DebugGBufferAlbedo = 256,

--- a/Source/Renderer/ShadowMap.h
+++ b/Source/Renderer/ShadowMap.h
@@ -28,7 +28,7 @@ public:
     static const int RESOLUTION = 4096; // Cannot increase past 16384 on most hardware
     static const int CASCADE_COUNT = 4; // Increasing past 4 will require reworking the uniform buffer layout
     const float DEPTH_BIAS_PER_CASCADE[CASCADE_COUNT] = { 0.00125f, 0.0018f, 0.0035f, 0.009f };
-    const float SHADOW_DRAW_DISTANCE = 1000.0f;
+    const float SHADOW_DRAW_DISTANCE = 300.0f;
 
 public:
     ShadowMap();

--- a/Source/Renderer/UniformBuffer.h
+++ b/Source/Renderer/UniformBuffer.h
@@ -19,7 +19,8 @@ enum class UniformBufferType
     ShadowsBuffer = 2,
     PerDrawBuffer = 3,
     PerMaterialBuffer = 4,
-    TerrainBuffer = 5
+    TerrainBuffer = 5,
+    TerrainDetailsBuffer = 6,
 };
 
 // Plain old uniform data for scene
@@ -79,6 +80,11 @@ struct PerDrawUniformData
     Color colorSmoothness;
     BindlessTextureHandle albedoTexture;
     BindlessTextureHandle normalMapTexture;
+};
+
+struct TerrainDetailsData
+{
+    Vector4 detailPositions[DetailBatch::MaxInstancesPerBatch];
 };
 
 struct PerMaterialUniformData

--- a/Source/Scene/Terrain.cpp
+++ b/Source/Scene/Terrain.cpp
@@ -20,6 +20,7 @@ void TerrainLayer::serialize(PropertyTable& table)
     table.serialize("material", material, (ResourcePPtr<Material>)nullptr);
     table.serialize("detail_mesh", detailMesh, (ResourcePPtr<Mesh>)nullptr);
     table.serialize("detail_material", detailMaterial, (ResourcePPtr<Material>)nullptr);
+    table.serialize("detail_scale", detailScale, Vector2::one());
 }
 
 Terrain::Terrain(GameObject* gameObject)
@@ -80,7 +81,7 @@ void Terrain::drawProperties()
     ImGui::DragFloat2("Tile Size", &terrainLayers_[0].textureTileSize.x, 0.1f, 0.5f, 50.0f);
     ImGui::DragFloat2("Tile Offset", &terrainLayers_[0].textureTileOffset.x, 0.1f, 0.0f, 50.0f);
     ImGui::Spacing();
-	
+
     if (ImGui::TreeNode("Terrain Layers"))
     {
         if (ImGui::Button("Add Layer"))
@@ -88,26 +89,32 @@ void Terrain::drawProperties()
             terrainLayers_.resize(terrainLayers_.size() + 1);
         }
 
-        for (unsigned int layer = 1; layer < terrainLayers_.size(); layer++)
+        for (unsigned int layerIndex = 1; layerIndex < terrainLayers_.size(); layerIndex++)
         {
-            ImGui::PushID(layer);
+            ImGui::PushID(layerIndex);
 
-            ImGui::ResourceSelect<Material>("Material", "Select Layer Material", terrainLayers_[layer].material);
-            ImGui::DragFloat2("Tile Size", &terrainLayers_[layer].textureTileSize.x, 0.1f, 0.5f, 50.0f);
-            ImGui::DragFloat2("Tile Offset", &terrainLayers_[layer].textureTileOffset.x, 0.1f, 0.0f, 50.0f);
+            TerrainLayer& layer = terrainLayers_[layerIndex];
+
+            ImGui::ResourceSelect<Material>("Material", "Select Layer Material", layer.material);
+            ImGui::DragFloat2("Tile Size", &layer.textureTileSize.x, 0.1f, 0.5f, 50.0f);
+            ImGui::DragFloat2("Tile Offset", &layer.textureTileOffset.x, 0.1f, 0.0f, 50.0f);
             ImGui::Spacing();
 
-            ImGui::DragFloat("Altitude", &terrainLayers_[layer].altitudeBorder, 0.1f, 0.0f, 300.0f);
-            ImGui::DragFloat("Transition", &terrainLayers_[layer].altitudeTransition, 0.1f, 0.0f, 20.0f);
+            ImGui::DragFloat("Altitude", &layer.altitudeBorder, 0.1f, 0.0f, 300.0f);
+            ImGui::DragFloat("Transition", &layer.altitudeTransition, 0.1f, 0.0f, 20.0f);
             ImGui::Spacing();
 
-            ImGui::DragFloat("Slope", &terrainLayers_[layer].slopeBorder, 0.01f, -1.0f, 1.0f);
-            ImGui::DragFloat("Hardness", &terrainLayers_[layer].slopeHardness, 0.01f, 0.001f, 1.0f);
+            ImGui::DragFloat("Slope", &layer.slopeBorder, 0.01f, -1.0f, 1.0f);
+            ImGui::DragFloat("Hardness", &layer.slopeHardness, 0.01f, 0.001f, 1.0f);
             ImGui::Spacing();
 
-            ImGui::ResourceSelect<Mesh>("Detail Mesh", "Select Detail Mesh", terrainLayers_[layer].detailMesh);
-            ImGui::ResourceSelect<Material>("Detail Material", "Select Detail Material", terrainLayers_[layer].detailMaterial);
+            ImGui::ResourceSelect<Mesh>("Detail Mesh", "Select Detail Mesh", layer.detailMesh);
+            ImGui::ResourceSelect<Material>("Detail Material", "Select Detail Material", layer.detailMaterial);
+            ImGui::DragFloat2("Detail Scale", &layer.detailScale.x, 0.05f, 0.01f, 100.0f);
             ImGui::Spacing();
+
+            // Prevent detail scale min being bigger than max
+            layer.detailScale.x = layer.detailScale.minComponent();
 
             ImGui::PopID();
         }

--- a/Source/Scene/Terrain.cpp
+++ b/Source/Scene/Terrain.cpp
@@ -18,6 +18,8 @@ void TerrainLayer::serialize(PropertyTable& table)
     table.serialize("texture_tile_size", textureTileSize, Vector2(10.0f, 10.0f));
     table.serialize("texture_tile_offset", textureTileOffset, Vector2::zero());
     table.serialize("material", material, (ResourcePPtr<Material>)nullptr);
+    table.serialize("detail_mesh", detailMesh, (ResourcePPtr<Mesh>)nullptr);
+    table.serialize("detail_material", detailMaterial, (ResourcePPtr<Material>)nullptr);
 }
 
 Terrain::Terrain(GameObject* gameObject)
@@ -101,6 +103,10 @@ void Terrain::drawProperties()
 
             ImGui::DragFloat("Slope", &terrainLayers_[layer].slopeBorder, 0.01f, -1.0f, 1.0f);
             ImGui::DragFloat("Hardness", &terrainLayers_[layer].slopeHardness, 0.01f, 0.001f, 1.0f);
+            ImGui::Spacing();
+
+            ImGui::ResourceSelect<Mesh>("Detail Mesh", "Select Detail Mesh", terrainLayers_[layer].detailMesh);
+            ImGui::ResourceSelect<Material>("Detail Material", "Select Detail Material", terrainLayers_[layer].detailMaterial);
             ImGui::Spacing();
 
             ImGui::PopID();

--- a/Source/Scene/Terrain.cpp
+++ b/Source/Scene/Terrain.cpp
@@ -51,8 +51,17 @@ void Terrain::drawProperties()
 {
     ImGui::DragFloat3("Size", &dimensions_.x, 1.0f, 1.0f, 4096.0f);
     ImGui::ColorEdit3("Water Color", &waterColor_.r);
+
+    float prevWaterDepth = waterDepth_;
     ImGui::DragFloat("Water Depth", &waterDepth_, 0.1f, 0.0f, 100.0f);
     ImGui::Spacing();
+
+    // If the water depth is changed, objects on the terrain need regenerating
+    if (fabs(prevWaterDepth - waterDepth_) > 0.001f)
+    {
+        placeObjects();
+        placeDetailMeshes();
+    }
 
     // Make a pseudo-hash of the terrain generation parameters before editing
     float genParams = (float)seed_ + fractalSmoothness_ + mountainScale_ + islandFactor_;

--- a/Source/Scene/Terrain.cpp
+++ b/Source/Scene/Terrain.cpp
@@ -378,7 +378,7 @@ void Terrain::generateDetailPositions(DetailBatch& batch, const TerrainLayer& la
 
         // Pick a random point
         float x = random_float(batch.bounds.min().x, batch.bounds.max().x);
-        float z = random_float(batch.bounds.max().x, batch.bounds.max().z);
+        float z = random_float(batch.bounds.min().z, batch.bounds.max().z);
         float y = sampleHeightmap(x, z);
 
         // Respect the layer's altitude settings

--- a/Source/Scene/Terrain.cpp
+++ b/Source/Scene/Terrain.cpp
@@ -363,6 +363,10 @@ void Terrain::placeDetailMeshes()
 
 void Terrain::generateDetailPositions(DetailBatch& batch, const TerrainLayer& layer) const
 {
+    // Use the batch centre as the seed
+    // This ensures that multiple runs are deterministic.
+    srand((unsigned int)batch.bounds.centre().x * (unsigned int)batch.bounds.centre().y + seed_);
+
     // Reset the number of positions in the batch
     batch.count = 0;
 

--- a/Source/Scene/Terrain.h
+++ b/Source/Scene/Terrain.h
@@ -6,6 +6,7 @@
 #include "Math/Color.h"
 #include "Math/Vector2.h"
 #include "Math/Vector3.h"
+#include "Math/Vector4.h"
 
 class Material;
 
@@ -26,6 +27,17 @@ struct TerrainLayer : ISerializedObject
     Vector2 detailScale = Vector2::one();
 
     void serialize(PropertyTable& table) override;
+};
+
+// A group of detail meshes drawn in a single batch
+struct DetailBatch
+{
+    const static int MaxInstancesPerBatch = 1024;
+
+    int count;
+    Mesh* mesh;
+    Material* material;
+    Vector4 instancePositions[MaxInstancesPerBatch];
 };
 
 class Terrain : public Component
@@ -55,8 +67,12 @@ public:
     // The depth of the water at its deepest point
     float waterDepth() const { return waterDepth_; }
 
+    // The layers on the terrain
     const TerrainLayer* layers() const { return &terrainLayers_.front(); }
     int layerCount() const { return (int)terrainLayers_.size(); }
+
+    // The detail mesh batches on the terrain
+    const std::vector<DetailBatch>& detailBatches() const { return detailMeshBatches_; }
 
 private:
     Mesh* mesh_;
@@ -78,9 +94,13 @@ private:
     // A list of objects placed on the terrain
     std::vector<GameObject*> placedObjects_;
 
+    // A list of detail mesh layers on the terrain
+    std::vector<DetailBatch> detailMeshBatches_;
+
     // Regenerates the terrain
     void generateTerrain();
     void placeObjects();
+    void placeDetailMeshes();
 
     // Gets the heightmap height at a specified point
     // The x and z coordinates are in world space.

--- a/Source/Scene/Terrain.h
+++ b/Source/Scene/Terrain.h
@@ -3,6 +3,7 @@
 #include "Scene/Component.h"
 #include "Renderer/Mesh.h"
 #include "Renderer/Texture.h"
+#include "Math/Bounds.h"
 #include "Math/Color.h"
 #include "Math/Vector2.h"
 #include "Math/Vector3.h"
@@ -38,6 +39,8 @@ struct DetailBatch
     Mesh* mesh;
     Material* material;
     Vector4 instancePositions[MaxInstancesPerBatch];
+    Bounds bounds;
+    float drawDistance;
 };
 
 class Terrain : public Component
@@ -102,7 +105,10 @@ private:
     void placeObjects();
     void placeDetailMeshes();
 
+    // Generates detail positions for the given detail batch
+    void generateDetailPositions(DetailBatch &batch, const TerrainLayer &layer) const;
+
     // Gets the heightmap height at a specified point
     // The x and z coordinates are in world space.
-    float sampleHeightmap(float x, float z);
+    float sampleHeightmap(float x, float z) const;
 };

--- a/Source/Scene/Terrain.h
+++ b/Source/Scene/Terrain.h
@@ -17,7 +17,12 @@ struct TerrainLayer : ISerializedObject
     float slopeHardness = 1.0f;
     Vector2 textureTileSize = Vector2(10.0f, 10.0f);
     Vector2 textureTileOffset = Vector2::zero();
-    Material* material = ResourceManager::instance()->load<Material>("Resources/Materials/ground_grass_01.material");;
+    Material* material = ResourceManager::instance()->load<Material>("Resources/Materials/ground_grass_01.material");
+
+    // Detail mesh settings
+    // The detail mesh is drawn if both the mesh & material are assigned
+    Mesh* detailMesh = nullptr;
+    Material* detailMaterial = nullptr;
 
     void serialize(PropertyTable& table) override;
 };

--- a/Source/Scene/Terrain.h
+++ b/Source/Scene/Terrain.h
@@ -23,6 +23,7 @@ struct TerrainLayer : ISerializedObject
     // The detail mesh is drawn if both the mesh & material are assigned
     Mesh* detailMesh = nullptr;
     Material* detailMaterial = nullptr;
+    Vector2 detailScale = Vector2::one();
 
     void serialize(PropertyTable& table) override;
 };

--- a/Source/Scene/Terrain.h
+++ b/Source/Scene/Terrain.h
@@ -21,12 +21,6 @@ struct TerrainLayer : ISerializedObject
     Vector2 textureTileOffset = Vector2::zero();
     Material* material = ResourceManager::instance()->load<Material>("Resources/Materials/ground_grass_01.material");
 
-    // Detail mesh settings
-    // The detail mesh is drawn if both the mesh & material are assigned
-    Mesh* detailMesh = nullptr;
-    Material* detailMaterial = nullptr;
-    Vector2 detailScale = Vector2::one();
-
     void serialize(PropertyTable& table) override;
 };
 
@@ -36,8 +30,6 @@ struct DetailBatch
     const static int MaxInstancesPerBatch = 1024;
 
     int count;
-    Mesh* mesh;
-    Material* material;
     Vector4 instancePositions[MaxInstancesPerBatch];
     Bounds bounds;
     float drawDistance;
@@ -60,6 +52,8 @@ public:
 
     const Mesh* mesh() const { return mesh_; }
     const Texture* heightmap() const { return &heightMap_; }
+    const Mesh* detailMesh() const { return detailMesh_; }
+    const Material* detailMaterial() const { return detailMaterial_; }
 
     // Total size of the terrain, in m, in X,Y,Z
     Vector3 size() const { return dimensions_; }
@@ -80,6 +74,11 @@ public:
 private:
     Mesh* mesh_;
     Texture heightMap_;
+    Mesh* detailMesh_;
+    Material* detailMaterial_;
+    Vector2 detailScale_;
+    Vector2 detailAltitudeLimits_;
+    float detailSlopeLimit_;
     Vector3 dimensions_;
     Color waterColor_;
     float waterDepth_;
@@ -106,7 +105,7 @@ private:
     void placeDetailMeshes();
 
     // Generates detail positions for the given detail batch
-    void generateDetailPositions(DetailBatch &batch, const TerrainLayer &layer, uint32_t seed) const;
+    void generateDetailPositions(DetailBatch &batch, uint32_t seed) const;
 
     // Gets the heightmap height at a specified point
     // The x and z coordinates are in world space.

--- a/Source/Scene/Terrain.h
+++ b/Source/Scene/Terrain.h
@@ -111,4 +111,8 @@ private:
     // Gets the heightmap height at a specified point
     // The x and z coordinates are in world space.
     float sampleHeightmap(float x, float z) const;
+
+    // Gets the heightmap normal at a specified point
+    // The x and z coordinates are in world space.
+    Vector3 sampleHeightmapNormal(float x, float z) const;
 };

--- a/Source/Scene/Terrain.h
+++ b/Source/Scene/Terrain.h
@@ -106,7 +106,7 @@ private:
     void placeDetailMeshes();
 
     // Generates detail positions for the given detail batch
-    void generateDetailPositions(DetailBatch &batch, const TerrainLayer &layer) const;
+    void generateDetailPositions(DetailBatch &batch, const TerrainLayer &layer, uint32_t seed) const;
 
     // Gets the heightmap height at a specified point
     // The x and z coordinates are in world space.


### PR DESCRIPTION
This branch adds grass detail meshes to the terrain

- Make the terrain scale smaller, to match real-world sizes
- Add grass detail meshes
- Improve per-draw ubo to allow non-static-mesh draws
- Add translucency information to GBuffer
- Add double-sided lighting a-la crysis 1

Risk - High
This branch changes the terrain system, terrain prefab, lighting system and uniform buffer management.
It also changes the scale of the terrain, which may affect gameplay.