### PR TITLE
Ambient Occlusion

### DIFF
--- a/Engine.vcxproj
+++ b/Engine.vcxproj
@@ -135,6 +135,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="Resources\Shaders\Deferred-AmbientOcclusion.shader" />
     <None Include="Resources\Shaders\Deferred-Debug.shader" />
     <None Include="Resources\Shaders\Deferred-Lighting.shader" />
     <None Include="Resources\Shaders\Includes\Atmosphere.inc.shader" />

--- a/Engine.vcxproj.filters
+++ b/Engine.vcxproj.filters
@@ -385,5 +385,8 @@
     <None Include="Resources\Shaders\TerrainDetail.shader">
       <Filter>Shaders</Filter>
     </None>
+    <None Include="Resources\Shaders\Deferred-AmbientOcclusion.shader">
+      <Filter>Shaders</Filter>
+    </None>
   </ItemGroup>
 </Project>

--- a/Resources/Scenes/startup.scene
+++ b/Resources/Scenes/startup.scene
@@ -2,8 +2,11 @@
     gameobjects::0 {
         prefab = Resources\Prefabs\Terrain.prefab
     }
-    sun_intensity = 4.4
-    sun_rotation = 16 140
-    fog_density = 0.016
-    fog_height_falloff = 0.036
+    ambient_intensity = 1.567
+    sun_intensity = 5.8
+    sun_rotation = 26 45
+    fog_density = 0.028
+    fog_height_falloff = 0.16
+    ambient_occlusion_distance = 5.7
+    ambient_occlusion_falloff = 3
 }

--- a/Resources/Shaders/Deferred-AmbientOcclusion.shader
+++ b/Resources/Shaders/Deferred-AmbientOcclusion.shader
@@ -1,0 +1,85 @@
+
+#include "Common.inc.shader"
+#include "UniformBuffers.inc.shader"
+
+#define USE_SCREENSPACE_VERT_SHADER
+#define USE_GBUFFER_READ
+#include "Deferred.inc.shader"
+
+#ifdef FRAGMENT_SHADER
+
+layout(binding = 8) uniform sampler2D _TerrainHeightmap;
+
+out vec4 fragColor;
+
+/*
+* Computes a 2d rotation matrix that is different per pixel
+* Uses "interleaved gradient noise" from
+* "Next Generation PostProcessing in Call of Duty: Advanced Warfare", [Jimemez14]
+*/
+mat2 randomRotationIGL()
+{
+    // From [Jimenez14], slide 123
+    vec3 magic = vec3(0.06711056, 0.00583715, 52.9829189);
+    float rotation = fract(magic.z * fract(dot(gl_FragCoord.xy, magic.xy)));
+    float sinRotation = sin(rotation);
+    float cosRotation = cos(rotation);
+
+    return mat2(sinRotation, cosRotation, -cosRotation, sinRotation);
+}
+
+/*
+ * Returns the terrain world space y at the specified world pos.
+ */
+float sampleHeightmap(vec3 worldPos)
+{
+    return texture(_TerrainHeightmap, worldPos.xz / _TerrainSize.xz).r * _TerrainSize.y - _WaterColorDepth.a;
+}
+
+void main()
+{
+    // Sample the gBuffer textures
+    SurfaceProperties surface = readGBuffer();
+
+    // Retrive the world space position by sampling the depth buffer
+    vec3 worldPosition = readGBufferWorldPos();
+
+    // This is inspired by the ambient occlusion system explained in
+    // "Rendering the World of Far Cry 4" [McAuley2015] (From GDC15)
+    // The approach is a ssao-style sampling of a heightfield
+    // we already have a terrain heightfield, with (almost) the entire
+    // landscape in it, so just sample that.
+    // The heightfield should really be blurred, but this seems to work ok.
+
+    // We use poisson disk sampling of the heightmap, like [McAuley2015]
+    // Compute the rotation matrix for the disks for this pixel
+    // We use interleaved gradient noise [Jimenez15] to rotate the precomputed disks
+    mat2 diskRotation = randomRotationIGL(); // different per gl_fragCoord
+
+    const int tapCount = 16;
+    float sum = 0.0;
+    for (int tap = 0; tap < tapCount; ++tap)
+    {
+        // Offset the world position to get the height sampling pos
+        vec2 offset = (diskRotation * _AmbientOcclusionPoissonDisks[tap]) * _AmbientOcclusionDistance;
+        vec3 samplingPosition = worldPosition + vec3(offset.x, 0.0, offset.y);
+
+        // Sample the heightmap at that point
+        float heightmapHeight = sampleHeightmap(samplingPosition);
+
+        // If the point is lower than the heightmap, it isnt visible
+        if (heightmapHeight < worldPosition.y)
+        {
+            sum += 1.0;
+        }
+    }
+
+    // The ao is based on the % of unoccluded samples
+    // Also provide a power ramp for artistic control
+    float ambientOcclusion = pow(min(1.0, sum / float(tapCount) * 1.2), _AmbientOcclusionFalloff);
+
+    // Output the ao into the gbuffer
+    fragColor = vec4(ambientOcclusion);
+}
+
+#endif // FRAGMENT_SHADER

--- a/Resources/Shaders/Deferred-Lighting.shader
+++ b/Resources/Shaders/Deferred-Lighting.shader
@@ -33,7 +33,7 @@ void main()
     vec3 sunColor = _LightDirectionIntensity.w * TDirection(worldPosition + vec3(0.0, Rg, 0.0), _LightDirectionIntensity.xyz);
 
     // Compute the ambient and direct light separately
-    vec3 ambientLight = surface.diffuseColor * _AmbientColor.rgb;
+    vec3 ambientLight = surface.diffuseColor * _AmbientColor.rgb * surface.occlusion;
     vec3 directLight = PhysicallyBasedBRDF(surface, sunColor, sunDir, viewDir);
 
     // Add translucent lighting

--- a/Resources/Shaders/Deferred-Lighting.shader
+++ b/Resources/Shaders/Deferred-Lighting.shader
@@ -38,7 +38,7 @@ void main()
 
     // Modulate the ambient light by the ambient occlusion factor
 #ifdef AMBIENT_OCCLUSION_ON
-    ambientLight *= surface.occlusion;
+    ambientLight *= surface.occlusion * 0.95 + 0.05; // *0.95+0.05 to prevent ao from making the surface completely black
 #endif
 
     // Add translucent lighting

--- a/Resources/Shaders/Deferred-Lighting.shader
+++ b/Resources/Shaders/Deferred-Lighting.shader
@@ -33,8 +33,13 @@ void main()
     vec3 sunColor = _LightDirectionIntensity.w * TDirection(worldPosition + vec3(0.0, Rg, 0.0), _LightDirectionIntensity.xyz);
 
     // Compute the ambient and direct light separately
-    vec3 ambientLight = surface.diffuseColor * _AmbientColor.rgb * surface.occlusion;
+    vec3 ambientLight = surface.diffuseColor * _AmbientColor.rgb;
     vec3 directLight = PhysicallyBasedBRDF(surface, sunColor, sunDir, viewDir);
+
+    // Modulate the ambient light by the ambient occlusion factor
+#ifdef AMBIENT_OCCLUSION_ON
+    ambientLight *= surface.occlusion;
+#endif
 
     // Add translucent lighting
     // "Vegetation Procedural Animation and Shading in Crysis" [Sousa08] suggested adding a term based on -N.L

--- a/Resources/Shaders/Includes/DeferredGBuffer.inc.shader
+++ b/Resources/Shaders/Includes/DeferredGBuffer.inc.shader
@@ -6,7 +6,7 @@
 
 // GBuffer Layout
 // RT0: Albedo (RGB), Gloss (A)
-// RT1: Normal (RG), NormalZSign*Gloss (B), Translucency (a, 2 bits)
+// RT1: Normal (RG), NormalZSign*Gloss (B), Translucency (a)
 
 // Stores surface properties into the gbuffer format
 void packGBuffer(SurfaceProperties surface, out vec4 gbuffer0, out vec4 gbuffer1)

--- a/Resources/Shaders/Includes/UniformBuffers.inc.shader
+++ b/Resources/Shaders/Includes/UniformBuffers.inc.shader
@@ -18,6 +18,13 @@ layout(std140, binding = 0) uniform scene_data
     // Fog settings
     uniform float _FogDensity;
     uniform float _FogHeightFalloff;
+
+    // Ambient occlusion settings
+    uniform float _AmbientOcclusionDistance;
+    uniform float _AmbientOcclusionFalloff;
+
+    // Precomputed poisson disk offsets for ambient occlusion
+    uniform vec2 _AmbientOcclusionPoissonDisks[16];
 };
 
 // Camera uniform buffer

--- a/Resources/Shaders/TerrainDetail.shader
+++ b/Resources/Shaders/TerrainDetail.shader
@@ -14,6 +14,7 @@ layout(location = 3) in vec2 _texcoord;
 
 out vec3 worldNormal;
 out vec2 texcoord;
+out float occlusion;
 
 void main()
 {
@@ -51,6 +52,9 @@ void main()
 
     // Texcoord does not need to be modified.
     texcoord = _texcoord;
+
+    // The top should be non-occluded, the bottom should be occluded
+    occlusion = _position.y;
 }
 
 #endif // VERTEX_SHADER
@@ -59,11 +63,11 @@ void main()
 
 in vec3 worldNormal;
 in vec2 texcoord;
+in float occlusion;
 
 void main()
 {
     SurfaceProperties surface;
-    surface.occlusion = 1.0;
 
     // Sample the albedo texture for the diffuse color
 #ifdef TEXTURE_ON
@@ -95,6 +99,9 @@ void main()
 
     // Grass doesn't use normal mapping
     surface.worldNormal = worldNormal;
+
+    // The bottom of grass is occluded
+    surface.occlusion = max(occlusion, 0.5);
 
     // Output surface properties to the gbuffer
     writeToGBuffer(surface);

--- a/Source/Math/Random.cpp
+++ b/Source/Math/Random.cpp
@@ -10,6 +10,23 @@ float random_float(float min, float max)
     return min + (random_float() * (max - min));
 }
 
+Vector2 random_in_unit_circle()
+{
+    // Find a random direction using monte carlo
+    Vector2 dir;
+    float sqrMagnitude;
+
+    do
+    {
+        dir.x = random_float(-1.0f, 1.0f);
+        dir.y = random_float(-1.0f, 1.0f);
+        sqrMagnitude = dir.sqrMagnitude();
+    } while (sqrMagnitude > 1.0f || sqrMagnitude < 0.1f);
+
+    // Return *without* normalizing it.
+    return dir;
+}
+
 Vector2 random_direction_2d()
 {
     float angle = random_float();

--- a/Source/Math/Random.h
+++ b/Source/Math/Random.h
@@ -9,6 +9,9 @@ float random_float();
 // Returns a random number between min and max.
 float random_float(float min, float max);
 
+// Returns a random vector inside the unit circle.
+Vector2 random_in_unit_circle();
+
 // Returns a random direction vector of unit length.
 Vector2 random_direction_2d();
 

--- a/Source/RenderManager.cpp
+++ b/Source/RenderManager.cpp
@@ -32,6 +32,7 @@ RenderManager::RenderManager()
     addShaderFeatureMenuItem(SF_TerrainDetailMeshes, "Terrain Details");
     addShaderFeatureMenuItem(SF_ExtraTerrainDetails, "Extra Terrain Details");
     addShaderFeatureMenuItem(SF_Translucency, "Translucency");
+    addShaderFeatureMenuItem(SF_AmbientOcclusion, "Ambient Occlusion");
 
     // Set up menu items for showing debugging modes
     addDebugModeMenuItem(RenderDebugMode::None, "None");

--- a/Source/Renderer/Renderer.cpp
+++ b/Source/Renderer/Renderer.cpp
@@ -382,10 +382,9 @@ void Renderer::executeDeferredAmbientOcclusionPass() const
     // We only want to render into the occlusion gbuffer channel (gbuffer 0 alpha).
     glColorMask(false, false, false, true);
 
-    // Use multiply blending for alpha (= occlusion) so existing ao information is not lost
+    // Use min blending for alpha (= occlusion) so existing ao information is not lost
     glEnable(GL_BLEND);
-    glBlendEquationSeparate(GL_DST_COLOR, GL_DST_ALPHA);
-    glBlendFuncSeparate(GL_ONE, GL_ZERO, GL_DST_ALPHA, GL_ZERO);
+    glBlendEquation(GL_MIN);
 
     // Render the ao shader full screen
     executeFullScreen(deferredAmbientOcclusionShader_, ALL_SHADER_FEATURES);

--- a/Source/Renderer/Renderer.cpp
+++ b/Source/Renderer/Renderer.cpp
@@ -155,7 +155,7 @@ void Renderer::createGBuffer()
 
     // Create the textures    
     gbufferTextures_[0] = new Texture(TextureFormat::RGBA8, targetFramebuffer_->width(), targetFramebuffer_->height());
-    gbufferTextures_[1] = new Texture(TextureFormat::RGBA1010102, targetFramebuffer_->width(), targetFramebuffer_->height());
+    gbufferTextures_[1] = new Texture(TextureFormat::RGBA8, targetFramebuffer_->width(), targetFramebuffer_->height());
     assert(GBUFFER_RENDER_TARGETS == 2); // should be one higher than the last index
 
     // Bind the gbuffer textures for sampling in deferred passes

--- a/Source/Renderer/Renderer.cpp
+++ b/Source/Renderer/Renderer.cpp
@@ -382,11 +382,19 @@ void Renderer::executeDeferredAmbientOcclusionPass() const
     // We only want to render into the occlusion gbuffer channel (gbuffer 0 alpha).
     glColorMask(false, false, false, true);
 
+    // Use multiply blending for alpha (= occlusion) so existing ao information is not lost
+    glEnable(GL_BLEND);
+    glBlendEquationSeparate(GL_DST_COLOR, GL_DST_ALPHA);
+    glBlendFuncSeparate(GL_ONE, GL_ZERO, GL_DST_ALPHA, GL_ZERO);
+
     // Render the ao shader full screen
     executeFullScreen(deferredAmbientOcclusionShader_, ALL_SHADER_FEATURES);
 
     // Reset the color mask when done
     glColorMask(true, true, true, true);
+
+    // Reset blending state
+    glDisable(GL_BLEND);
 }
 
 void Renderer::executeDeferredLightingPass() const

--- a/Source/Renderer/Renderer.h
+++ b/Source/Renderer/Renderer.h
@@ -53,6 +53,7 @@ private:
     Shader* terrainDetailMeshShader_;
 
     // Shaders used for deferred passes
+    Shader* deferredAmbientOcclusionShader_;
     Shader* deferredLightingShader_;
     Shader* deferredDebugShader_;
 
@@ -68,6 +69,9 @@ private:
 
     // Sky lookup textures
     Texture skyTransmittanceLUT_;
+
+    // The poisson disks used for ambient occlusion
+    Vector4 poissonDisks_[16];
 
     // GBuffer management
     void createGBuffer();
@@ -87,6 +91,7 @@ private:
     void executeFullScreen(Shader* shader, ShaderFeatureList shaderFeatures) const;
 
     // Methods for each render pass
+    void executeDeferredAmbientOcclusionPass() const;
     void executeDeferredLightingPass() const;
     void executeDeferredDebugPass() const;
     void executeWaterPass() const;

--- a/Source/Renderer/Shader.cpp
+++ b/Source/Renderer/Shader.cpp
@@ -196,6 +196,7 @@ std::string ShaderVariant::createFeatureDefines() const
     if (hasFeature(SF_DebugGBufferGloss)) defines += "#define DEBUG_GBUFFER_GLOSS \n";
     if (hasFeature(SF_DebugShadows)) defines += "#define DEBUG_SHADOWS \n";
     if (hasFeature(SF_DebugShadowCascades)) defines += "#define DEBUG_SHADOW_CASCADES \n";
+    if (hasFeature(SF_AmbientOcclusion)) defines += "#define AMBIENT_OCCLUSION_ON \n";
 
     return defines;
 }

--- a/Source/Renderer/Shader.h
+++ b/Source/Renderer/Shader.h
@@ -39,6 +39,9 @@ enum ShaderFeature
     // Enables computation of translucency lighting
     SF_Translucency = 262144,
 
+    // Enables a heightmap-based ambient occlusion pass
+    SF_AmbientOcclusion = 2097152,
+
     // GBuffer debugging modes
     SF_DebugGBufferDepth = 32768,
     SF_DebugGBufferAlbedo = 256,

--- a/Source/Renderer/UniformBuffer.h
+++ b/Source/Renderer/UniformBuffer.h
@@ -38,7 +38,11 @@ struct SceneUniformData
     // Fog settings
     float fogDensity;
     float fogHeightFalloff;
-    float fogPadding[2];
+
+    // Ambient occlusion settings
+    float ambientOcclusionDistance;
+    float ambientOcclusionFalloff;
+    Vector4 ambientOcclusionPoissonDisks[16];
 };
 
 // Plain old uniform data for camera

--- a/Source/Scene/Scene.cpp
+++ b/Source/Scene/Scene.cpp
@@ -35,6 +35,10 @@ void Scene::drawEditor()
         ImGui::Spacing();
         ImGui::DragFloat("Fog Density", &fogDensity_, 0.0001f, 0.0001f, 0.3f);
         ImGui::DragFloat("Fog Height Falloff", &fogHeightFalloff_, 0.0001f, 0.0001f, 0.1f);
+
+        ImGui::Spacing();
+        ImGui::DragFloat("AO Distance", &ambientOcclusionDistance_, 0.05f, 5.0f, 50.0f);
+        ImGui::DragFloat("AO Intensity", &ambientOcclusionFalloff_, 0.01f, 0.3f, 3.0f);
     }
 }
 
@@ -65,6 +69,8 @@ void Scene::serialize(PropertyTable &table)
     table.serialize("sun_rotation", sunRotation_, Vector2(30.0f, 0.0f));
     table.serialize("fog_density", fogDensity_, 0.005f);
     table.serialize("fog_height_falloff", fogHeightFalloff_, 0.023f);
+    table.serialize("ambient_occlusion_distance", ambientOcclusionDistance_, 10.0f);
+    table.serialize("ambient_occlusion_falloff", ambientOcclusionFalloff_, 2.0f);
 }
 
 void Scene::createGameObjects()

--- a/Source/Scene/Scene.h
+++ b/Source/Scene/Scene.h
@@ -22,6 +22,8 @@ public:
     Quaternion sunRotation() const { return Quaternion::euler(sunRotation_.x, sunRotation_.y, 0.0f); }
     float fogDensity() const { return fogDensity_; }
     float fogHeightFalloff() const { return fogHeightFalloff_; }
+    float ambientOcclusionDistance() const { return ambientOcclusionDistance_; }
+    float ambientOcclusionFalloff() const { return ambientOcclusionFalloff_; }
 
     // Opens the scene when selected
     void onOpenAction() override;
@@ -49,4 +51,6 @@ private:
     Vector2 sunRotation_;
     float fogDensity_;
     float fogHeightFalloff_;
+    float ambientOcclusionDistance_;
+    float ambientOcclusionFalloff_;
 };


### PR DESCRIPTION
This branch implements 2 forms of ambient occlusion, heightfield-based and grass ao. The heightfield ambient occlusion performs ssao-like sampling of the terrain heightfield in a screen-space pass, and the grass ao adds ao into the gbuffer at the base of grass meshes.

Note - Ambient occlusion was previously not stored in the GBuffer. To make space, the normals + gloss are now packed into 3 channels [Sousa13]. The new mapping for world space normals is precise with only 8bits per channel, so all gbuffers are now RGBA8 (gBuffer1 was previously RGBA1010102). This gives extra precision (2bits -> 8bits) for the translucency data.

Major Changes:
- Modify GBuffer layout to make space for occlusion
- Use ambient occlusion in deferred lighting pass
- Add heightfield-based AO
- Add grass AO
- Add scene settings for ao distance & falloff